### PR TITLE
ignore empty strings in converter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore empty strings in converter.
+  [tschanzt]
 
 
 1.0.0 (2016-09-07)

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -17,6 +17,8 @@ class ReferenceDataListConverter(converter.BaseDataConverter):
         else:
             result = []
             for item in value:
+                if not item:
+                    continue
                 result.append(self.widget.context.unrestrictedTraverse(
                     item.encode("utf-8")))
             return result


### PR DESCRIPTION
@maethu this fixes a bug on relationlist field, that it always self references.