### PR TITLE
Support chameleon by not rendering handlebar templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support chameleon by not rendering handlebar templates. [jone]
 
 
 1.0.4 (2016-09-19)

--- a/ftw/referencewidget/templates/handlebars.html
+++ b/ftw/referencewidget/templates/handlebars.html
@@ -1,0 +1,41 @@
+<script id="refbrowser-template" type="text/x-handlebars-template">
+    <div class="refbrowser overlay">
+            <div class="pathbar">
+                <div class="path"></div>
+                <div class="search">
+                    <input class="searchField" name="refbrowser-search" type="text" />
+                    <button class="searchButton" name="refbrowser-search" type="submit">{{search}}</button>
+                </div>
+            </div>
+            <div class="listing">
+                <ul></ul>
+            </div>
+            <div class="formcontrols">
+                <div class="closecontainer">
+                 <button type="cancel" class="cancel">{{close}}</button>
+                </div>
+                <div class="batchingcontainer" />
+            </div>
+    </div>
+</script>
+
+<script id="node-template" type="text/x-handlebars-template">
+    <a data-path="{{path}}" href="#" data-clickable={{clickable}}>{{title}}</a>
+</script>
+
+<script id="listing-template" type="text/x-handlebars-template">
+    <li class="ref_list_entry {{addclass}}" data-traversable="{{traversable}}" data-path="{{path}}" data-id="{{id}}">
+        {{{checkbox}}}
+        <{{{tag}}} class="{{content-type}}" {{{extras}}}> {{title}} </{{{tag}}}>
+    </li>
+</script>
+
+<script id="checkbox-template" type="text/x-handlebars-template">
+        <input type="{{type}}" class="ref-checkbox" {{{selected}}} name="{{name}}" value="{{path}}" />
+</script>
+
+<script id="batch_template" type="text/x-handlebars-template">
+        <div class="refbrowser_batching">
+            {{{batching}}}
+        </div>
+</script>

--- a/ftw/referencewidget/templates/referencewidget_input.pt
+++ b/ftw/referencewidget/templates/referencewidget_input.pt
@@ -1,4 +1,4 @@
-<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+<tal:html xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="ftw.referencewidget">
 
@@ -14,45 +14,6 @@
                         i18n:translate="">Browse</button>
 </div>
 
-<script id="refbrowser-template" type="text/x-handlebars-template">
-    <div class="refbrowser overlay">
-            <div class="pathbar">
-                <div class="path"></div>
-                <div class="search">
-                    <input class="searchField" name="refbrowser-search" type="text" />
-                    <button class="searchButton" name="refbrowser-search" type="submit">{{search}}</button>
-                </div>
-            </div>
-            <div class="listing">
-                <ul></ul>
-            </div>
-            <div class="formcontrols">
-                <div class="closecontainer">
-                 <button type="cancel" class="cancel" i18n:translate="">{{close}}</button>
-                </div>
-                <div class="batchingcontainer" />
-            </div>
-    </div>
-</script>
+<tal:HANDLEBARS replace="structure view/handlebars_html" />
 
-<script id="node-template" type="text/x-handlebars-template">
-    <a data-path="{{path}}" href="#" data-clickable={{clickable}}>{{title}}</a>
-</script>
-
-<script id="listing-template" type="text/x-handlebars-template">
-    <li class="ref_list_entry {{addclass}}" data-traversable="{{traversable}}" data-path="{{path}}" data-id="{{id}}">
-        {{{checkbox}}}
-        <{{{tag}}} class="{{content-type}}" {{{extras}}}> {{title}} </{{{tag}}}>
-    </li>
-</script>
-
-<script id="checkbox-template" type="text/x-handlebars-template">
-        <input type="{{type}}" class="ref-checkbox" {{{selected}}} name="{{name}}" value="{{path}}" />
-</script>
-
-<script id="batch_template" type="text/x-handlebars-template">
-        <div class="refbrowser_batching">
-            {{{batching}}}
-        </div>
-</script>
-</html>
+</tal:html>

--- a/ftw/referencewidget/tests/test_utils.py
+++ b/ftw/referencewidget/tests/test_utils.py
@@ -3,9 +3,13 @@ from ftw.referencewidget.browser.utils import get_traversal_types
 from ftw.referencewidget.interfaces import IReferenceSettings
 from ftw.referencewidget.testing import FTW_REFERENCE_FUNCTIONAL_TESTING
 from ftw.referencewidget.tests.views.form import TestView
+from ftw.testbrowser import browsing
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
 from zope.component import getUtility
+import transaction
 
 
 class TestFieldConverter(TestCase):
@@ -65,3 +69,12 @@ class TestFieldConverter(TestCase):
         self.assertEquals(6, len(result))
         self.assertTrue('Document' not in result)
         self.assertTrue('Event' not in result)
+
+    @browsing
+    def test_handlebar_templates_available(self, browser):
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        transaction.commit()
+        browser.login().open(view='test-refwidget')
+        self.assertTrue(browser.css('#refbrowser-template').first)
+        self.assertTrue(browser.css('#node-template').first)
+        self.assertTrue(browser.css('#listing-template').first)

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -15,6 +15,7 @@ from zope.interface import implementer
 from zope.interface import implementsOnly
 from zope.schema.interfaces import IList
 import json
+import os
 
 
 class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
@@ -29,6 +30,13 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
     nonselectable = None
     start = None
     override = None
+
+    # Handlebar templates should not be rendered with a page templating engine,
+    # because 1) <script> tags are not rendered by the zope.pagetemplate
+    # implementation and 2) chameleon has troubles with handlebars.
+    with open(os.path.join(os.path.dirname(__file__),
+                           'templates', 'handlebars.html'), 'r') as fio:
+        handlebars_html = fio.read()
 
     def __init__(self,
                  request,

--- a/test-plone-4.3.x-chameleon.cfg
+++ b/test-plone-4.3.x-chameleon.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+
+package-name = ftw.referencewidget
+test-egg += five.pt


### PR DESCRIPTION
The original page template implementation in zope.pagetemplate does not render within `<script>`-tags at all, thus the handlebars were not rendered until now.
But chameleon does render `<script>`-tags, but our handlebars are invalid from a page template point of view. Things such as tags with dynamic tagnames produce errors.

Since we cannot render the handlebar templates properly I have extracted them into a separate template so that we can include them statically.

I've also fixed some other errors and added a test configuration with chameleon.

⚠️ I'm unable to tell whether the widget still works or not, as the package contains no development-example and the tests are never really using the widget with a testbrowser (for example removing the templates does not break the tests).
@maethu please verify that I did not break anything.

/cc @tschanzt @mbaechtold 