### PR TITLE
Implement support for IList of IRelationChoice explicitly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,25 @@ The widget takes the following parameters:
  - allow_nonsearched_types: If this is set to true all the types will be traversable and selectable.
  - override: drops all global config and the base query if a list is passed to the widget. All types need to be added to be selectable.
 
+
+**IMPORTANT NOTE:**
+Currently this widget drops the SourceBinder concept, which has huge impact on the usability.
+
+The following combinations are supported.
+- RelationList with value_type Relation --> Stores a List of RelationValues
+- RelationList with value_type RelationChoice --> Stores a List of RelationValues
+- Relation --> Stores a RelationValue
+- List of RelationChoice --> Stores a list of absolute paths, without the portal root part
+
+
+
+TODO
+----
+
+- The SourceBinder concept needs to be implemented for better compatibility with everything/everyone else.
+- Proper Integration Tests using test behaviors with several configurations.
+
+
 Screenshots
 -----------
 The general Listing:

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Show absolute path starting at the plone root for the selected value.
+  [mathias.leimgruber]
+
 - Remove the list style type and the obsolete spacing for the selected elements.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Remove the list style type and the obsolete spacing for the selected elements.
+  [mathias.leimgruber]
+
 - Implement support for IList of IRelationChoice explicitly.
   Check Readme for more informations
   [mathias.leimgruber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement support for IList of IRelationChoice explicitly.
+  Check Readme for more informations
+  [mathias.leimgruber]
 
 
 1.1.0 (2016-09-27)

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -34,6 +34,7 @@
 
     <adapter factory=".converter.ReferenceDataListConverter" />
     <adapter factory=".converter.ReferenceDataChoiceConverter" />
+    <adapter factory=".converter.ReferenceDataListWithChoiceConverter" />
 
     <include package=".browser" />
     <include package=".tests.views" />

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -1,9 +1,11 @@
 from ftw.referencewidget.interfaces import IReferenceWidget
+from plone import api
 from z3c.form import converter
-from z3c.relationfield.interfaces import IRelationList
 from z3c.relationfield.interfaces import IRelation
-
+from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapts
+from zope.schema.interfaces import IList
+import os
 
 
 class ReferenceDataListConverter(converter.BaseDataConverter):
@@ -49,3 +51,27 @@ class ReferenceDataChoiceConverter(converter.BaseDataConverter):
     def toWidgetValue(self, value):
         if value:
             return '/'.join(value.getPhysicalPath())
+
+
+class ReferenceDataListWithChoiceConverter(converter.BaseDataConverter):
+    """Converter of IList of IRelationChoices."""
+
+    adapts(IList, IReferenceWidget)
+
+    def toFieldValue(self, value):
+        if not value:
+            return []
+        elif isinstance(value, (unicode, str)):
+            return [value]
+        else:
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            return map(
+                lambda path: os.path.relpath(path, portal_path),
+                filter(lambda path: bool(path), value))
+
+    def toWidgetValue(self, value):
+        if value:
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            return map(lambda path: '/'.join([portal_path, path]), value)
+        else:
+            return value

--- a/ftw/referencewidget/resources/refwidget.css
+++ b/ftw/referencewidget/resources/refwidget.css
@@ -117,6 +117,12 @@ div.refbrowser.overlay {
     display:block;
 }
 
+.selected_items ul {
+  margin-left: 0;
+  padding-left: 0;
+  list-style-type: none;
+}
+
 li.ref_list_entry.traversable {
     background: #f2f2f2;
 }

--- a/ftw/referencewidget/resources/refwidget.js
+++ b/ftw/referencewidget/resources/refwidget.js
@@ -63,7 +63,7 @@
             if (item["path"] === ""){
               return;
             }
-            item["title"] = item["title"] + " (" + item["path"] + ")";
+            item["title"] = item["title"] + " (" + item["path"].substring(portal_url.replace(window.location.origin, '').length) + ")";
             item["selectable"] = true;
             item["traversable"] = false;
             item['addclass'] = "";


### PR DESCRIPTION
Purpose:
ftw.news filter_py_path is a list of relation choices, which stores paths. With this change this Widget can be used as drop-in replacement. It stores an loads the same values as the ContentTreeWidget.

This PR also updates the readme with some valuable informations.


Further I made some visual improvements:

- Display only the relevant part of the url (selected items)
<img width="888" alt="screen shot 2016-10-04 at 11 25 50" src="https://cloud.githubusercontent.com/assets/437933/19069089/a70c170c-8a25-11e6-839e-20b826023418.png">

- No list styles anymore
<img width="564" alt="screen shot 2016-10-04 at 11 10 13" src="https://cloud.githubusercontent.com/assets/437933/19069088/a7027b34-8a25-11e6-8249-97c3ec7d4ad6.png">
