### PR TITLE
Implement support for ITextLine with ReferenceWidget.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ The following combinations are supported.
 - RelationList with value_type RelationChoice --> Stores a List of RelationValues
 - Relation --> Stores a RelationValue
 - List of RelationChoice --> Stores a list of absolute paths, without the portal root part
+- TextLine --> Stores a absolute path as string, without the portal root part
 
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement support for ITextLine only with ReferenceWidget.
+  [mathias.leimgruber]
 
 
 1.2.0 (2016-10-04)

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -35,6 +35,7 @@
     <adapter factory=".converter.ReferenceDataListConverter" />
     <adapter factory=".converter.ReferenceDataChoiceConverter" />
     <adapter factory=".converter.ReferenceDataListWithChoiceConverter" />
+    <adapter factory=".converter.ReferenceDataTextConverter" />
 
     <include package=".browser" />
     <include package=".tests.views" />

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -5,6 +5,7 @@ from z3c.relationfield.interfaces import IRelation
 from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapts
 from zope.schema.interfaces import IList
+from zope.schema.interfaces import ITextLine
 import os
 
 
@@ -51,6 +52,32 @@ class ReferenceDataChoiceConverter(converter.BaseDataConverter):
     def toWidgetValue(self, value):
         if value:
             return '/'.join(value.getPhysicalPath())
+
+
+class ReferenceDataTextConverter(converter.BaseDataConverter):
+
+    adapts(ITextLine, IReferenceWidget)
+
+    def toFieldValue(self, value):
+        if not value:
+            return
+        elif isinstance(value, list):
+            # Since there is always a empty hidden field it's always a list :-(
+            value, = [path for path in value if path]
+
+        portal_path = '/'.join(api.portal.get().getPhysicalPath())
+        return os.path.relpath(value, portal_path)
+
+    def toWidgetValue(self, value):
+        if value:
+
+            # For Backwards compatibility with ContentTreeFieldWidget
+            value = value.startswith('/') and value[1:] or value
+
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            return '/'.join([portal_path, value])
+        else:
+            return value
 
 
 class ReferenceDataListWithChoiceConverter(converter.BaseDataConverter):


### PR DESCRIPTION
This allows the following field/widget combination


``` 
    form.widget(link=ReferenceWidgetFactory)
    link = schema.TextLine(
        title=_(u'label_link', default=u'Link'),
        description=_(u'help_link', default=u''),
        required=False,
        )
``` 