### PR TITLE
respect missing_value of field

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Respect missing_value set by the field.
+  [tschanzt]
+
 - Implement support for ITextLine only with ReferenceWidget.
   [mathias.leimgruber]
 

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -15,7 +15,7 @@ class ReferenceDataListConverter(converter.BaseDataConverter):
 
     def toFieldValue(self, value):
         if not value:
-            return
+            return self.field.missing_value
         elif isinstance(value, unicode):
             return [self.widget.context.unrestrictedTraverse(
                 value.encode("utf8"))]
@@ -41,7 +41,7 @@ class ReferenceDataChoiceConverter(converter.BaseDataConverter):
 
     def toFieldValue(self, value):
         if not value:
-            return
+            return self.field.missing_value
         elif isinstance(value, unicode):
             return self.widget.context.unrestrictedTraverse(
                 value.encode("utf8"))


### PR DESCRIPTION
The Referencewidget should respect missing_values of fields so giving an empty value doesn't fail.