### PR TITLE
Use plone.app.redirector to follow renamed and moved content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use plone.app.redirector to follow renamed and moved content.
+  Also do not fail if the content has been removed.
+  [mathias.leimgruber]
 
 
 1.2.3 (2016-10-18)


### PR DESCRIPTION
This fixes a widget render error if:
- The obj has been renamed/moves (also multiple times)
- The obj has been removed.

TESTS:
I know there should be two new testcases, but since there is currently none, I'm not able to write them.

It needs some work in advance... like some test behaviors with fields in order to test the widget with real use-cases. 