### PR TITLE
Implement a ObjSourceBinder 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,23 +17,68 @@ The widget takes the following parameters:
  - override: drops all global config and the base query if a list is passed to the widget. All types need to be added to be selectable.
 
 
-**IMPORTANT NOTE:**
-Currently this widget drops the SourceBinder concept, which has huge impact on the usability.
+ContextSourceBinder
+-------------------
 
-The following combinations are supported.
+With a `RelationeChoice` or `RelationList` of `RelationChoice` a source can be configured along with the field.
+The `ContextSourceBinder` makes sure that only valid content can be selected.
+
+By default, the source binder only checks for a valid portal_type when selecting content.
+
+The default_filter implementation therefore looks like this:
+
+.. code:: python
+
+    def default_filter(source, value):
+        """"
+        Return ``True`` when the object is selectable, ``False``
+        when it is not selectable.
+        
+        """"
+        return value.portal_type in get_selectable_types_by_source(source)
+
+Feel free to add your own filter method as source parameter in your field.
+Example:
+
+.. code:: python
+
+    def custom_filter(source, value):
+        return bool(..)
+
+    ...
+
+    directives.widget(realtionchoice_restricted_title=ReferenceWidgetFactory)
+    realtionchoice_restricted_title = RelationChoice(
+        title=_(u'Related Choice Restricted Title'),
+        source=ReferenceObjSourceBinder(
+            selectable_function=custom_filter),
+        default=None,
+        required=False,
+    )
+
+The `filter` takes two parameter the actual source object and a value, which is the content object.
+
+Only `ReferenceObjSourceBinder` are supported. The SourceBinder takes the following parameters:
+
+- selectable: These types are selectable
+- nonselectable: These Types are not selectable
+- allow_nonsearched_types: If this is set to true all the types will be traversable and selectable.
+- override: drops all global config and the base query if a list is passed to the widget. All types need to be added to be selectable.
+- selectable_function: Custom function to determine if a content is selectable or not.
+
+The parameters are same as for the widget (Backwards compatibility with 1.x releases).
+
+
+Fields combinations (Registered converter)
+------------------------------------------
+
+The following combinations are supported:
+
 - RelationList with value_type Relation --> Stores a List of RelationValues
 - RelationList with value_type RelationChoice --> Stores a List of RelationValues
 - Relation --> Stores a RelationValue
 - List of RelationChoice --> Stores a list of absolute paths, without the portal root part
 - TextLine --> Stores a absolute path as string, without the portal root part
-
-
-
-TODO
-----
-
-- The SourceBinder concept needs to be implemented for better compatibility with everything/everyone else.
-- Proper Integration Tests using test behaviors with several configurations.
 
 
 Screenshots

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement ReferenceObjPathSource for IRelationChoice fields.
+  [mathias.leimgruber]
 
 
 1.3.0 (2016-11-09)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -29,3 +29,18 @@ class IRelatedItems(Interface):
     )
 
 alsoProvides(IRelatedItems, IFormFieldProvider)
+
+
+class IRelationChoiceExample(Interface):
+    """Demo behavior containing a RelationChoice (single value).
+
+    """
+    directives.widget(realtionchoice=ReferenceWidgetFactory)
+    realtionchoice = RelationChoice(
+        title=_(u'Related Choice'),
+        source=ReferenceWidgetPathSourceBinder(),
+        default=None,
+        required=False,
+    )
+
+alsoProvides(IRelationChoiceExample, IFormFieldProvider)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -44,3 +44,20 @@ class IRelationChoiceExample(Interface):
     )
 
 alsoProvides(IRelationChoiceExample, IFormFieldProvider)
+
+
+class IRelationChoiceRestricted(Interface):
+    """Demo behavior containing a RelationChoice (single value).
+    But it's not allowd to reference a folder.
+
+    """
+    directives.widget(realtionchoice_restricted=ReferenceWidgetFactory)
+    realtionchoice_restricted = RelationChoice(
+        title=_(u'Related Choice Restricted'),
+        source=ReferenceWidgetPathSourceBinder(
+            nonselectable=['Folder']),
+        default=None,
+        required=False,
+    )
+
+alsoProvides(IRelationChoiceRestricted, IFormFieldProvider)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -46,6 +46,10 @@ class IRelationChoiceExample(Interface):
 alsoProvides(IRelationChoiceExample, IFormFieldProvider)
 
 
+def custom_filter(source, value):
+    return value.Title() == 'Immutable title'
+
+
 class IRelationChoiceRestricted(Interface):
     """Demo behavior containing a RelationChoice (single value).
     But it's not allowd to reference a folder.
@@ -56,6 +60,15 @@ class IRelationChoiceRestricted(Interface):
         title=_(u'Related Choice Restricted'),
         source=ReferenceWidgetPathSourceBinder(
             nonselectable=['Folder']),
+        default=None,
+        required=False,
+    )
+
+    directives.widget(realtionchoice_restricted_title=ReferenceWidgetFactory)
+    realtionchoice_restricted_title = RelationChoice(
+        title=_(u'Related Choice Restricted Title'),
+        source=ReferenceWidgetPathSourceBinder(
+            filter_method=custom_filter),
         default=None,
         required=False,
     )

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -1,0 +1,31 @@
+from ftw.referencewidget.sources import ReferenceWidgetPathSourceBinder
+from plone.app.dexterity import MessageFactory as _
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel.model import fieldset
+from z3c.relationfield.schema import RelationChoice, RelationList
+from zope.interface import alsoProvides
+from zope.interface import Interface
+from ftw.referencewidget.widget import ReferenceWidgetFactory
+
+
+class IRelatedItems(Interface):
+    """Behavior, which provides the same functionality as the
+    plone.app.relationfield IRelatedItems behavior, BUT it uses a different
+    widget.
+
+    """
+
+    fieldset('categorization',
+             label=_(u'Categorization'),
+             fields=['relatedItems'])
+
+    directives.widget(relatedItems=ReferenceWidgetFactory)
+    relatedItems = RelationList(
+        title=_(u'label_related_items', default=u'Related Items'),
+        default=[],
+        value_type=RelationChoice(title=u"Related",
+                                  source=ReferenceWidgetPathSourceBinder()),
+        required=False,
+    )
+
+alsoProvides(IRelatedItems, IFormFieldProvider)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -1,11 +1,12 @@
-from ftw.referencewidget.sources import ReferenceWidgetPathSourceBinder
+from ftw.referencewidget.sources import ReferenceObjSourceBinder
+from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.app.dexterity import MessageFactory as _
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel.model import fieldset
 from z3c.relationfield.schema import RelationChoice, RelationList
 from zope.interface import alsoProvides
 from zope.interface import Interface
-from ftw.referencewidget.widget import ReferenceWidgetFactory
 
 
 class IRelatedItems(Interface):
@@ -24,7 +25,7 @@ class IRelatedItems(Interface):
         title=_(u'label_related_items', default=u'Related Items'),
         default=[],
         value_type=RelationChoice(title=u"Related",
-                                  source=ReferenceWidgetPathSourceBinder()),
+                                  source=ReferenceObjSourceBinder()),
         required=False,
     )
 
@@ -38,7 +39,7 @@ class IRelationChoiceExample(Interface):
     directives.widget(realtionchoice=ReferenceWidgetFactory)
     realtionchoice = RelationChoice(
         title=_(u'Related Choice'),
-        source=ReferenceWidgetPathSourceBinder(),
+        source=ReferenceObjSourceBinder(),
         default=None,
         required=False,
     )
@@ -58,7 +59,7 @@ class IRelationChoiceRestricted(Interface):
     directives.widget(realtionchoice_restricted=ReferenceWidgetFactory)
     realtionchoice_restricted = RelationChoice(
         title=_(u'Related Choice Restricted'),
-        source=ReferenceWidgetPathSourceBinder(
+        source=ReferenceObjSourceBinder(
             nonselectable=['Folder']),
         default=None,
         required=False,
@@ -67,8 +68,8 @@ class IRelationChoiceRestricted(Interface):
     directives.widget(realtionchoice_restricted_title=ReferenceWidgetFactory)
     realtionchoice_restricted_title = RelationChoice(
         title=_(u'Related Choice Restricted Title'),
-        source=ReferenceWidgetPathSourceBinder(
-            filter_method=custom_filter),
+        source=ReferenceObjSourceBinder(
+            selectable_function=custom_filter),
         default=None,
         required=False,
     )

--- a/ftw/referencewidget/browser/utils.py
+++ b/ftw/referencewidget/browser/utils.py
@@ -6,8 +6,11 @@ from plone.api import portal
 from plone.batching import Batch
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
 from zope.component import getUtility
 from zope.i18n import translate
+from zope.schema import List
 
 
 def get_traversal_types(widget):
@@ -40,24 +43,42 @@ def remove_blacklist_from_types(widget, blacklist):
     return types_to_search
 
 
-def get_selectable_types(source):
-    if source.override and source.selectable:
-        return source.selectable
+def get_selectable_types_by_source(source):
+    return get_selectable_types_base(source)
+
+
+def get_selectable_types(widget):
+    source = widget
+    field = widget.field
+    if isinstance(field, RelationList) or isinstance(field, List):
+        value_type = getattr(field, 'value_type', None)
+        if isinstance(value_type, RelationChoice):
+            source = value_type.source(widget.context)
+    elif isinstance(field, RelationChoice):
+        source = field.source(widget.context)
+
+    return get_selectable_types_base(source)
+
+
+def get_selectable_types_base(obj):
+    if obj.override and obj.selectable:
+        return obj.selectable
 
     registry = getUtility(IRegistry)
     referencesettings = registry.forInterface(IReferenceSettings)
-    portal_props = getToolByName(source.context, 'portal_properties')
+    portal_props = getToolByName(obj.context, 'portal_properties')
     non_selectable = set()
-    if not source.allow_nonsearched_types:
+    if not obj.allow_nonsearched_types:
         non_selectable = set(portal_props.site_properties.types_not_searched)
     non_selectable = non_selectable.union(
         set(referencesettings.block_additional))
     non_selectable = non_selectable.difference(
         set(referencesettings.select_additional))
 
-    non_selectable = non_selectable.union(set(source.nonselectable))
-    non_selectable = non_selectable.difference(set(source.selectable))
-    return remove_blacklist_from_types(source, non_selectable)
+    non_selectable = non_selectable.union(set(obj.nonselectable))
+    non_selectable = non_selectable.difference(set(obj.selectable))
+    return remove_blacklist_from_types(obj, non_selectable)
+
 
 
 def get_path_from_widget_start(widget):

--- a/ftw/referencewidget/browser/utils.py
+++ b/ftw/referencewidget/browser/utils.py
@@ -80,7 +80,6 @@ def get_selectable_types_base(obj):
     return remove_blacklist_from_types(obj, non_selectable)
 
 
-
 def get_path_from_widget_start(widget):
     effective_path = ""
     if not callable(widget.start):

--- a/ftw/referencewidget/browser/utils.py
+++ b/ftw/referencewidget/browser/utils.py
@@ -60,24 +60,25 @@ def get_selectable_types(widget):
     return get_selectable_types_base(source)
 
 
-def get_selectable_types_base(obj):
-    if obj.override and obj.selectable:
-        return obj.selectable
+def get_selectable_types_base(source_or_widget):
+    if source_or_widget.override and source_or_widget.selectable:
+        return source_or_widget.selectable
 
     registry = getUtility(IRegistry)
     referencesettings = registry.forInterface(IReferenceSettings)
-    portal_props = getToolByName(obj.context, 'portal_properties')
+    portal_props = getToolByName(source_or_widget.context, 'portal_properties')
     non_selectable = set()
-    if not obj.allow_nonsearched_types:
+    if not source_or_widget.allow_nonsearched_types:
         non_selectable = set(portal_props.site_properties.types_not_searched)
     non_selectable = non_selectable.union(
         set(referencesettings.block_additional))
     non_selectable = non_selectable.difference(
         set(referencesettings.select_additional))
 
-    non_selectable = non_selectable.union(set(obj.nonselectable))
-    non_selectable = non_selectable.difference(set(obj.selectable))
-    return remove_blacklist_from_types(obj, non_selectable)
+    non_selectable = non_selectable.union(set(source_or_widget.nonselectable))
+    non_selectable = non_selectable.difference(
+        set(source_or_widget.selectable))
+    return remove_blacklist_from_types(source_or_widget, non_selectable)
 
 
 def get_path_from_widget_start(widget):

--- a/ftw/referencewidget/browser/utils.py
+++ b/ftw/referencewidget/browser/utils.py
@@ -40,24 +40,24 @@ def remove_blacklist_from_types(widget, blacklist):
     return types_to_search
 
 
-def get_selectable_types(widget):
-    if widget.override and widget.selectable:
-        return widget.selectable
+def get_selectable_types(source):
+    if source.override and source.selectable:
+        return source.selectable
 
     registry = getUtility(IRegistry)
     referencesettings = registry.forInterface(IReferenceSettings)
-    portal_props = getToolByName(widget.context, 'portal_properties')
+    portal_props = getToolByName(source.context, 'portal_properties')
     non_selectable = set()
-    if not widget.allow_nonsearched_types:
+    if not source.allow_nonsearched_types:
         non_selectable = set(portal_props.site_properties.types_not_searched)
     non_selectable = non_selectable.union(
         set(referencesettings.block_additional))
     non_selectable = non_selectable.difference(
         set(referencesettings.select_additional))
 
-    non_selectable = non_selectable.union(set(widget.nonselectable))
-    non_selectable = non_selectable.difference(set(widget.selectable))
-    return remove_blacklist_from_types(widget, non_selectable)
+    non_selectable = non_selectable.union(set(source.nonselectable))
+    non_selectable = non_selectable.difference(set(source.selectable))
+    return remove_blacklist_from_types(source, non_selectable)
 
 
 def get_path_from_widget_start(widget):

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -39,7 +39,6 @@
     <adapter factory=".converter.ReferenceDataTextConverter" />
 
     <include package=".browser" />
-    <include package=".tests.views" />
 
     <adapter
         factory=".widget.ReferenceWidgetFactory"

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="ftw.referencewidget">
 
     <i18n:registerTranslations directory="locales" />
@@ -40,14 +41,22 @@
     <include package=".browser" />
     <include package=".tests.views" />
 
-        <adapter
+    <adapter
         factory=".widget.ReferenceWidgetFactory"
         provides="z3c.form.interfaces.IFieldWidget"
         for="z3c.relationfield.interfaces.IRelationList" />
 
-        <adapter
+    <adapter
         factory=".widget.ReferenceWidgetFactory"
         provides="z3c.form.interfaces.IFieldWidget"
         for="z3c.relationfield.interfaces.IRelation" />
+
+
+    <plone:behavior
+        title="Related items"
+        description="Adds the ability to assign related items"
+        provides=".behaviors.IRelatedItems"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
 
 </configure>

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -59,4 +59,12 @@
         for="plone.dexterity.interfaces.IDexterityContent"
         />
 
+    <!-- Some behaviors to demonstrate several use-cases -->
+    <plone:behavior
+        title="Relation choice demo behavior"
+        description="Adds the ability to assign one related item"
+        provides=".behaviors.IRelationChoiceExample"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
 </configure>

--- a/ftw/referencewidget/configure.zcml
+++ b/ftw/referencewidget/configure.zcml
@@ -67,4 +67,11 @@
         for="plone.dexterity.interfaces.IDexterityContent"
         />
 
+    <plone:behavior
+        title="Relation choice demo behavior with restricted source"
+        description="Adds the ability to assign one related item"
+        provides=".behaviors.IRelationChoiceRestricted"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
 </configure>

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -1,0 +1,38 @@
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import ISource
+from zope.interface import implements
+from ftw.referencewidget.browser.utils import get_selectable_types
+
+
+class ReferenceWidgetPathSource(object):
+
+    implements(ISource)
+
+    def __init__(self, context, selectable, nonselectable, override):
+        self.context = context
+
+    def __contains__(self, value):
+        obj = self._get_obj_by_path(value)
+        if not obj:
+            return False
+        return obj.portal_type in get_selectable_types(self)
+
+    def _get_obj_by_path(self, value):
+        return self.context.restrictedTraverse(value, None)
+
+
+class ReferenceWidgetPathSourceBinder(object):
+    implements(IContextSourceBinder)
+
+    def __init__(self, selectable=None,
+                 nonselectable=None,
+                 override=None):
+        self.selectable = selectable
+        self.nonselectable = nonselectable
+        self.override = override
+
+    def __call__(self, context):
+        return ReferenceWidgetPathSource(context,
+                                         self.selectable,
+                                         self.nonselectable,
+                                         self.override)

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -4,29 +4,37 @@ from zope.interface import implements
 from ftw.referencewidget.browser.utils import get_selectable_types_by_source
 
 
+def default_filter(source, value):
+    return value.portal_type in get_selectable_types_by_source(source)
+
+
 class ReferenceWidgetPathSource(object):
 
     implements(ISource)
 
-    def __init__(self, context, selectable, nonselectable, override,
-                 allow_nonsearched_types):
+    def __init__(self, context, filter_method, selectable, nonselectable,
+                 override, allow_nonsearched_types):
         self.context = context
+        self.filter_method = filter_method
         self.selectable = selectable
         self.nonselectable = nonselectable
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types
 
     def __contains__(self, value):
-        return value.portal_type in get_selectable_types_by_source(self)
+        return self.filter_method(source=self, value=value)
 
 
 class ReferenceWidgetPathSourceBinder(object):
     implements(IContextSourceBinder)
 
-    def __init__(self, selectable=None,
+    def __init__(self,
+                 filter_method=None,
+                 selectable=None,
                  nonselectable=None,
                  override=None,
                  allow_nonsearched_types=None):
+        self.filter_method = filter_method or default_filter
         self.selectable = selectable or []
         self.nonselectable = nonselectable or []
         self.override = override or False
@@ -34,6 +42,7 @@ class ReferenceWidgetPathSourceBinder(object):
 
     def __call__(self, context):
         return ReferenceWidgetPathSource(context,
+                                         self.filter_method,
                                          self.selectable,
                                          self.nonselectable,
                                          self.override,

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -5,45 +5,51 @@ from ftw.referencewidget.browser.utils import get_selectable_types_by_source
 
 
 def default_filter(source, value):
+    """"
+    Return ``True`` when the object is selectable, ``False``
+    when it is not selectable.
+
+    """
+
     return value.portal_type in get_selectable_types_by_source(source)
 
 
-class ReferenceWidgetPathSource(object):
+class ReferenceObjPathSource(object):
 
     implements(ISource)
 
-    def __init__(self, context, filter_method, selectable, nonselectable,
+    def __init__(self, context, selectable_function, selectable, nonselectable,
                  override, allow_nonsearched_types):
         self.context = context
-        self.filter_method = filter_method
+        self.selectable_function = selectable_function
         self.selectable = selectable
         self.nonselectable = nonselectable
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types
 
     def __contains__(self, value):
-        return self.filter_method(source=self, value=value)
+        return self.selectable_function(source=self, value=value)
 
 
-class ReferenceWidgetPathSourceBinder(object):
+class ReferenceObjSourceBinder(object):
     implements(IContextSourceBinder)
 
     def __init__(self,
-                 filter_method=None,
+                 selectable_function=None,
                  selectable=None,
                  nonselectable=None,
                  override=None,
                  allow_nonsearched_types=None):
-        self.filter_method = filter_method or default_filter
+        self.selectable_function = selectable_function or default_filter
         self.selectable = selectable or []
         self.nonselectable = nonselectable or []
         self.override = override or False
         self.allow_nonsearched_types = allow_nonsearched_types or False
 
     def __call__(self, context):
-        return ReferenceWidgetPathSource(context,
-                                         self.filter_method,
-                                         self.selectable,
-                                         self.nonselectable,
-                                         self.override,
-                                         self.allow_nonsearched_types)
+        return ReferenceObjPathSource(context,
+                                      self.selectable_function,
+                                      self.selectable,
+                                      self.nonselectable,
+                                      self.override,
+                                      self.allow_nonsearched_types)

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -1,24 +1,23 @@
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import ISource
 from zope.interface import implements
-from ftw.referencewidget.browser.utils import get_selectable_types
+from ftw.referencewidget.browser.utils import get_selectable_types_by_source
 
 
 class ReferenceWidgetPathSource(object):
 
     implements(ISource)
 
-    def __init__(self, context, selectable, nonselectable, override):
+    def __init__(self, context, selectable, nonselectable, override,
+                 allow_nonsearched_types):
         self.context = context
+        self.selectable = selectable
+        self.nonselectable = nonselectable
+        self.override = override
+        self.allow_nonsearched_types = allow_nonsearched_types
 
     def __contains__(self, value):
-        obj = self._get_obj_by_path(value)
-        if not obj:
-            return False
-        return obj.portal_type in get_selectable_types(self)
-
-    def _get_obj_by_path(self, value):
-        return self.context.restrictedTraverse(value, None)
+        return value.portal_type in get_selectable_types_by_source(self)
 
 
 class ReferenceWidgetPathSourceBinder(object):
@@ -26,13 +25,16 @@ class ReferenceWidgetPathSourceBinder(object):
 
     def __init__(self, selectable=None,
                  nonselectable=None,
-                 override=None):
-        self.selectable = selectable
-        self.nonselectable = nonselectable
-        self.override = override
+                 override=None,
+                 allow_nonsearched_types=None):
+        self.selectable = selectable or []
+        self.nonselectable = nonselectable or []
+        self.override = override or False
+        self.allow_nonsearched_types = allow_nonsearched_types or False
 
     def __call__(self, context):
         return ReferenceWidgetPathSource(context,
                                          self.selectable,
                                          self.nonselectable,
-                                         self.override)
+                                         self.override,
+                                         self.allow_nonsearched_types)

--- a/ftw/referencewidget/testing.py
+++ b/ftw/referencewidget/testing.py
@@ -1,6 +1,7 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from ftw.referencewidget.tests import builders
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE

--- a/ftw/referencewidget/testing.py
+++ b/ftw/referencewidget/testing.py
@@ -7,7 +7,6 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from zope.configuration import xmlconfig
-from Products.CMFCore.utils import getToolByName
 
 
 class FtwReferenceWidgetLayer(PloneSandboxLayer):

--- a/ftw/referencewidget/tests/__init__.py
+++ b/ftw/referencewidget/tests/__init__.py
@@ -1,0 +1,59 @@
+from ftw.referencewidget.testing import FTW_REFERENCE_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.content import Container
+from plone.dexterity.fti import DexterityFTI
+from plone.supermodel import model
+from unittest2 import TestCase
+from zope.interface import implements
+from zope.interface import Interface
+import transaction
+import widgets
+
+
+class ISampleContentSchema(model.Schema):
+    pass
+
+
+class ISampleContententMarker(Interface):
+    pass
+
+
+class SampleContent(Container):
+    implements(ISampleContententMarker)
+
+
+class FunctionalTestCase(TestCase):
+    layer = FTW_REFERENCE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()
+
+    def setup_fti(self, additional_behaviors=None):
+        types_tool = self.portal.portal_types
+
+        default_behaviors = [
+            'plone.app.dexterity.behaviors.metadata.IBasic',
+            'plone.app.content.interfaces.INameFromTitle'
+        ]
+
+        if additional_behaviors is None:
+            default_behaviors += [
+                'ftw.referencewidget.behaviors.IRelatedItems',
+            ]
+        else:
+            default_behaviors += additional_behaviors
+
+        fti = DexterityFTI('SampleContent')
+        fti.schema = 'ftw.referencewidget.tests.ISampleContentSchema'
+        fti.klass = 'ftw.referencewidget.tests.SampleContent'
+        fti.behaviors = tuple(default_behaviors)
+        fti.default_view = 'view'
+        types_tool._setObject('SampleContent', fti)
+
+        transaction.commit()

--- a/ftw/referencewidget/tests/builders.py
+++ b/ftw/referencewidget/tests/builders.py
@@ -1,0 +1,8 @@
+from ftw.builder import registry
+from ftw.builder.dexterity import DexterityBuilder
+
+class SampleContentBuilder(DexterityBuilder):
+    portal_type = 'SampleContent'
+
+registry.builder_registry.register(
+    'sample content', SampleContentBuilder)

--- a/ftw/referencewidget/tests/test_related_items_behavior.py
+++ b/ftw/referencewidget/tests/test_related_items_behavior.py
@@ -1,0 +1,67 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.referencewidget.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+import json
+import transaction
+
+
+class TestRelatedItemsReplacement(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRelatedItemsReplacement, self).setUp()
+        self.setup_fti()
+        self.grant('Manager')
+
+    @browsing
+    def test_relateditems_behavior_with_one_item(self, browser):
+        folder = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Items': folder})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(
+            [folder],
+            [relation.to_object for relation in content.relatedItems])
+
+    @browsing
+    def test_relateditems_behavior_with_multiple_items(self, browser):
+        folder1 = create(Builder('folder').titled(u'Some folder'))
+        folder2 = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Items': [folder1, folder2]})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(
+            [folder1, folder2],
+            [relation.to_object for relation in content.relatedItems])
+
+    @browsing
+    def test_relateditems_with_removed_relation(self, browser):
+        folder1 = create(Builder('folder').titled(u'Some folder'))
+        folder2 = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content')
+                         .titled(u'Sample content')
+                         .having(relatedItems=[folder1, folder2]))
+
+        self.portal.manage_delObjects([folder2.getId()])
+        transaction.commit()
+
+        browser.login().visit(content, view='@@edit')
+
+        self.assertEquals(
+            [folder1, None],
+            [relation.to_object for relation in content.relatedItems])
+
+        selected = json.loads(browser.css(
+            '.selected_items').first.attrib['data-select'])
+        self.assertEquals(1, len(selected), 'Expect only one item')
+        self.assertEquals(['/'.join(folder1.getPhysicalPath())],
+                          [item['path'] for item in selected])

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -1,0 +1,50 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.referencewidget.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+import json
+import transaction
+
+
+class TestRelationChoice(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRelationChoice, self).setUp()
+        self.setup_fti(additional_behaviors=[
+            'ftw.referencewidget.behaviors.IRelationChoiceExample'])
+        self.grant('Manager')
+
+    @browsing
+    def test_relation_choice(self, browser):
+        folder = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Choice': folder})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(folder, content.realtionchoice.to_object)
+
+        browser.login().visit(content, view='@@edit')
+        selected = json.loads(browser.css(
+            '.selected_items').first.attrib['data-select'])
+        self.assertEquals('/'.join(folder.getPhysicalPath()),
+                          selected[0]['path'])
+
+    @browsing
+    def test_relateditems_with_removed_relation(self, browser):
+        folder1 = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content')
+                         .titled(u'Sample content')
+                         .having(realtionchoice=folder1))
+
+        self.portal.manage_delObjects([folder1.getId()])
+        transaction.commit()
+
+        self.assertIsNone(content.realtionchoice.to_object)
+
+        browser.login().visit(content, view='@@edit')
+        self.assertNotIn('data-select',
+                         browser.css('.selected_items').first.attrib)

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -86,3 +86,27 @@ class TestRelationChoiceRestricted(FunctionalTestCase):
 
         self.assertEquals(content2,
                           content1.realtionchoice_restricted.to_object)
+
+    @browsing
+    def test_custom_filter_method_for_source_binder(self, browser):
+
+        folder = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Choice Restricted Title': folder})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(['There were some errors.'],
+                          statusmessages.error_messages())
+
+        folder.title = u'Immutable title'
+        transaction.commit()
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Choice Restricted Title': folder})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(folder,
+                          content.realtionchoice_restricted_title.to_object)

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.referencewidget.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
 import json
 import transaction
 
@@ -33,7 +34,7 @@ class TestRelationChoice(FunctionalTestCase):
                           selected[0]['path'])
 
     @browsing
-    def test_relateditems_with_removed_relation(self, browser):
+    def test_relation_choice_with_removed_relation(self, browser):
         folder1 = create(Builder('folder').titled(u'Some folder'))
 
         content = create(Builder('sample content')
@@ -48,3 +49,40 @@ class TestRelationChoice(FunctionalTestCase):
         browser.login().visit(content, view='@@edit')
         self.assertNotIn('data-select',
                          browser.css('.selected_items').first.attrib)
+
+
+class TestRelationChoiceRestricted(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRelationChoiceRestricted, self).setUp()
+        self.setup_fti(additional_behaviors=[
+            'ftw.referencewidget.behaviors.IRelationChoiceRestricted'])
+        self.grant('Manager')
+
+    @browsing
+    def test_relation_choice_folder_is_not_allowed(self, browser):
+        folder = create(Builder('folder').titled(u'Some folder'))
+
+        content = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content, view='@@edit')
+        browser.fill({'Related Choice Restricted': folder})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals('Constraint not satisfied',
+                          browser.css('.fieldErrorBox .error').first.text)
+        self.assertEquals(['There were some errors.'],
+                          statusmessages.error_messages())
+
+    @browsing
+    def test_other_types_are_allowed(self, browser):
+        content1 = create(Builder('sample content').titled(u'Some content'))
+
+        content2 = create(Builder('sample content').titled(u'Sample content'))
+
+        browser.login().visit(content1, view='@@edit')
+        browser.fill({'Related Choice Restricted': content2})
+        browser.find_button_by_label('Save').click()
+
+        self.assertEquals(content2,
+                          content1.realtionchoice_restricted.to_object)

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -88,7 +88,7 @@ class TestRelationChoiceRestricted(FunctionalTestCase):
                           content1.realtionchoice_restricted.to_object)
 
     @browsing
-    def test_custom_filter_method_for_source_binder(self, browser):
+    def test_custom_selectable_function_for_source_binder(self, browser):
 
         folder = create(Builder('folder').titled(u'Some folder'))
 

--- a/ftw/referencewidget/tests/views/form.py
+++ b/ftw/referencewidget/tests/views/form.py
@@ -1,3 +1,4 @@
+from ftw.referencewidget import _
 from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.z3cform.layout import FormWrapper
 from z3c.form.button import buttonAndHandler
@@ -5,11 +6,10 @@ from z3c.form.field import Fields
 from z3c.form.form import Form
 from z3c.relationfield.schema import RelationList
 from zope.interface import Interface
-from ftw.referencewidget import _
-import json
 
 
 class IFormSchema(Interface):
+
     relation = RelationList(
         title=_(u'Relation'),
         required=False)

--- a/ftw/referencewidget/tests/widgets.py
+++ b/ftw/referencewidget/tests/widgets.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 
@@ -9,7 +10,6 @@ class ReferenceBrowserWidget(PloneWidget):
     def match(node):
         if not node.tag == 'div' or 'field' not in node.classes:
             return False
-
         return bool(node.css('div.referencewidget'))
 
     def fill(self, values):
@@ -17,6 +17,21 @@ class ReferenceBrowserWidget(PloneWidget):
 
         if isinstance(values, basestring):
             field.value = values
+        elif isinstance(values, list):
+            for index, obj in enumerate(values):
+                template = deepcopy(field.node)
+                path = obj
+
+                if not isinstance(values, basestring):
+                    path = '/'.join(obj.getPhysicalPath())
+
+                if index == 0:
+                    field.value = path
+                else:
+                    new = deepcopy(template)
+                    new.value = path
+                    self.node.append(new)
+
         else:
             # Assume an DX object
             field.value = '/'.join(values.getPhysicalPath())

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -107,6 +107,9 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
 
         if isinstance(self.value, list):
             for item in self.value:
+                if not item:
+                    continue
+
                 obj = self.get_object_by_path(item)
                 if obj:
                     result.append(obj_to_dict(obj))

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -52,8 +52,8 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
         self.request = request
         self.block_traversal = block_traversal
         self.allow_traversal = allow_traversal
-        self.selectable = selectable
-        self.nonselectable = nonselectable
+        # self.selectable = selectable
+        # self.nonselectable = nonselectable
         self.start = start
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -52,8 +52,8 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
         self.request = request
         self.block_traversal = block_traversal
         self.allow_traversal = allow_traversal
-        # self.selectable = selectable
-        # self.nonselectable = nonselectable
+        self.selectable = selectable
+        self.nonselectable = nonselectable
         self.start = start
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types


### PR DESCRIPTION
To demonstrate the ContextSourceBinder there are some behaviors registered along with this package. 
The `IRelatedItems` behavior is a 1 to 1 replacement for the plone.app.relationfield IRelatedItems behavior. There are some more for testing. 

I was trying to not break the old behavior, where all the magic happens in the widget. 


Decisions:
- If there is a RelationChoice or RelationList (with RelationChoice) field the a `source` is more important than the widget config. 
- Other fields does still only respects the config from the widget. 
- If there is the same config on a widget and on the source, the source config will win. 
- Traversal still happens on the widget
- Selectable is in the source for RelationChoice (or list of RelationChoice)
- It's possible to pass a filter method to the source binder for different usecases.

Purpose:
- The ContextSourceBinders are validated with field, so they are very important to make sure the right content is referenced. 