### PR TITLE
Implement a additional `traversal_query` parameter for the widget.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ The widget takes the following parameters:
  - start: The path first opened. Can either be a callable or a path. Additionaly the strings "parent", "navroot", "ploneroot" can be used.
  - allow_nonsearched_types: If this is set to true all the types will be traversable and selectable.
  - override: drops all global config and the base query if a list is passed to the widget. All types need to be added to be selectable.
-
+- traversal_query: Updates the query used vor traversing by the given dict. The dict passed will be updated after everything is allready done. So make sure not to override sort_on/sort_order attributes.
 
 ContextSourceBinder
 -------------------
@@ -33,7 +33,7 @@ The default_filter implementation therefore looks like this:
         """"
         Return ``True`` when the object is selectable, ``False``
         when it is not selectable.
-        
+
         """"
         return value.portal_type in get_selectable_types_by_source(source)
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Implement a additional `traversal_query` parameter for the widget.
+  [mathias.leimgruber]
+
 - Implement ReferenceObjPathSource for IRelationChoice fields.
   [mathias.leimgruber]
 

--- a/ftw/referencewidget/browser/jsongenerator.py
+++ b/ftw/referencewidget/browser/jsongenerator.py
@@ -68,6 +68,7 @@ class ReferenceJsonEndpoint(BrowserView):
                               'depth': 1},
                      'is_folderish': True
                      }
+            query.update(widget.traversal_query)
 
             results_folderish = catalog(query)
 
@@ -76,6 +77,7 @@ class ReferenceJsonEndpoint(BrowserView):
                               'depth': 1},
                      'is_folderish': False
                      }
+            query.update(widget.traversal_query)
 
             results_content = catalog(query)
 
@@ -86,6 +88,7 @@ class ReferenceJsonEndpoint(BrowserView):
                               'depth': 1},
                      'is_folderish': True
                      }
+            query.update(widget.traversal_query)
 
             results_folder_select = catalog(query)
             results = results_folderish + results_content + results_folder_select
@@ -96,6 +99,7 @@ class ReferenceJsonEndpoint(BrowserView):
                               'depth': 1},
                      }
             query.update(sort_query)
+            query.update(widget.traversal_query)
             results = catalog(query)
 
         return results

--- a/ftw/referencewidget/browser/search.py
+++ b/ftw/referencewidget/browser/search.py
@@ -31,6 +31,8 @@ class SearchView(BrowserView):
                  'sort_on': self.request.get('sort_on',
                                              u'modified').encode('utf-8')}
 
+        query.update(self.context.traversal_query)
+
         catalog = getToolByName(self.context.context, 'portal_catalog')
         results = catalog(query)
         results, batch_html = extend_with_batching(self.context, results)

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -19,6 +19,10 @@ class ReferenceDataListConverter(converter.BaseDataConverter):
         elif isinstance(value, unicode):
             return [self.widget.context.unrestrictedTraverse(
                 value.encode("utf8"))]
+
+        elif isinstance(value, basestring):
+            return [self.widget.context.unrestrictedTraverse(value)]
+
         else:
             result = []
             for item in value:
@@ -45,6 +49,10 @@ class ReferenceDataChoiceConverter(converter.BaseDataConverter):
         elif isinstance(value, unicode):
             return self.widget.context.unrestrictedTraverse(
                 value.encode("utf8"))
+
+        elif isinstance(value, basestring):
+            return self.widget.context.unrestrictedTraverse(value)
+
         else:
             return self.widget.context.unrestrictedTraverse(
                 value[0].encode("utf-8"))

--- a/ftw/referencewidget/tests/test_json_view.py
+++ b/ftw/referencewidget/tests/test_json_view.py
@@ -7,6 +7,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from Products.ATContentTypes.interfaces.folder import IATFolder
 from unittest2 import TestCase
 import json
 
@@ -58,3 +59,16 @@ class TestJsonView(TestCase):
         result = result['items']
         self.assertFalse(result[0]['selectable'])
         self.assertTrue(result[1]['selectable'])
+
+    def test_additional_traversable_query_is_applied(self):
+        form = TestView(self.portal, self.portal.REQUEST)
+        form.update()
+        widget = form.form_instance.widgets['relation']
+
+        widget.traversal_query = {
+            'object_provides': [IATFolder.__identifier__]}
+        result = json.loads(ReferenceJsonEndpoint(
+            widget, widget.request)())['items']
+
+        self.assertEquals(1, len(result), 'Exepct only one item')
+        self.assertEquals('/plone/folder', result[0]['path'])

--- a/ftw/referencewidget/tests/test_search_view.py
+++ b/ftw/referencewidget/tests/test_search_view.py
@@ -7,6 +7,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from Products.ATContentTypes.interfaces.folder import IATFolder
 from unittest2 import TestCase
 import json
 
@@ -51,3 +52,17 @@ class TestGeneratePathbar(TestCase):
         self.assertEquals(1, len(items))
         self.assertEquals("/plone/testfolder", items[0]['path'])
         self.assertEquals("Testfolder (/plone/testfolder)", items[0]['title'])
+
+    def test_additional_traversable_query_is_applied(self):
+        create(Builder('file').titled("testfile"))
+
+        self.widget.request['term'] = 'tes'
+        self.widget.request['sort_on'] = 'sortable_title'
+        self.widget.traversal_query = {
+            'object_provides': [IATFolder.__identifier__]}
+
+        result = json.loads(SearchView(
+            self.widget, self.widget.request)())['items']
+
+        self.assertEquals(1, len(result), 'Exepct only one item')
+        self.assertEquals('/plone/testfolder', result[0]['path'])

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -33,6 +33,8 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
     start = None
     override = None
 
+    traversal_query = None
+
     # Handlebar templates should not be rendered with a page templating engine,
     # because 1) <script> tags are not rendered by the zope.pagetemplate
     # implementation and 2) chameleon has troubles with handlebars.
@@ -48,7 +50,8 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
                  nonselectable=[],
                  start='',
                  override=False,
-                 allow_nonsearched_types=False,):
+                 allow_nonsearched_types=False,
+                 traversal_query={}):
         self.request = request
         self.block_traversal = block_traversal
         self.allow_traversal = allow_traversal
@@ -57,6 +60,7 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
         self.start = start
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types
+        self.traversal_query = traversal_query
 
     def update(self):
         super(ReferenceBrowserWidget, self).update()
@@ -142,7 +146,8 @@ def ReferenceWidgetFactory(field,
                            nonselectable=[],
                            start='',
                            override=False,
-                           allow_nonsearched_types=False):
+                           allow_nonsearched_types=False,
+                           traversal_query={}):
     """IFieldWidget factory for DateTimePickerWidget."""
     return FieldWidget(field, ReferenceBrowserWidget(request,
                                                      block_traversal,
@@ -151,4 +156,5 @@ def ReferenceWidgetFactory(field,
                                                      nonselectable,
                                                      start,
                                                      override,
-                                                     allow_nonsearched_types))
+                                                     allow_nonsearched_types,
+                                                     traversal_query))


### PR DESCRIPTION
This allows us to apply more filter criteria to the traversal query:
Example:
- Filter for object_provides
- Filter for review_state