### PR TITLE
Render hidden input elements for stored references, instead of render them only by Javascript.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Render hidden input elements for given references, instead of
+  render them only by Javascript. This way the widget behaves more
+  like all other plone widgets.
+  [mathias.leimgruber]
+
 - Implement a additional `traversal_query` parameter for the widget.
   [mathias.leimgruber]
 

--- a/ftw/referencewidget/resources/refwidget.js
+++ b/ftw/referencewidget/resources/refwidget.js
@@ -55,32 +55,37 @@
 }
 
     initRefBrowser.prototype.loadSelectedItems = function(widget){
-        var container = widget.button.siblings('.selected_items');
+        var container = widget.field.find('.selected_items');
         if (!container.find('ul').is(':empty')){
           return;
         }
-        var data = container.data("select");
-        if (data !== undefined){
-          data.forEach(function(widget, item){
-            if (item["path"] === ""){
-              return;
-            }
-            item["title"] = item["title"] + " (" + item["path"].substring(portal_url.replace(window.location.origin, '').length) + ")";
-            item["selectable"] = true;
-            item["traversable"] = false;
-            item['addclass'] = "";
-            item['tag'] = "span";
-            item["selected"] = "checked=\"checked\"";
-            item["type"] = widget.sel_type;
-            item["name"] = widget.name;
-            item["checkbox"] = widget.checkbox_template(item);
 
-            var node = $(widget.list_template(item));
-            widget.AddremoveLink(node);
+        $(container).find('[type="hidden"]').each(function(index, item){
+          var context = {};
+          var inputElement = $(item);
 
-            $(container).find("ul").append(node);
-          }.bind(null, widget));
-        }
+          if (inputElement.val() === ""){
+            return;
+          }
+
+          context["path"] = inputElement.val();
+          context["title"] = inputElement.data("title") + " (" + context["path"].substring(portal_url.replace(window.location.origin, '').length) + ")";
+          context["selectable"] = true;
+          context["traversable"] = false;
+          context['addclass'] = "";
+          context['tag'] = "span";
+          context["selected"] = "checked=\"checked\"";
+          context["type"] = widget.sel_type;
+          context["name"] = widget.name;
+          context["checkbox"] = widget.checkbox_template(context);
+
+          inputElement.remove();
+
+          var node = $(widget.list_template(context));
+          widget.AddremoveLink(node);
+
+          $(container).find("ul").append(node);
+        });
     };
 
     initRefBrowser.prototype.openOverlay = function(widget, event){

--- a/ftw/referencewidget/templates/referencewidget_input.pt
+++ b/ftw/referencewidget/templates/referencewidget_input.pt
@@ -6,7 +6,16 @@
                                              data-url view/form_url;
                                              data-type view/is_list;
                                              data-trans view/translations">
-<div class="selected_items" tal:attributes="data-select view/js_value"><ul class="sortable"></ul></div>
+<div class="selected_items">
+    <ul class="sortable"></ul>
+    <!-- Rendered from the backend. This is gonna be converted to a list placed in the ul above by javascript-->
+    <tal:items repeat="item view/get_items">
+        <input type="hidden" tal:attributes="name view/name;
+                                             value item/path;
+                                             data-title item/title" />
+    </tal:items>
+</div>
+
 <input type="hidden" tal:attributes="name view/name" />
 <button type="button" tal:attributes="id string:browse-${view/id};
                                       name string:browse-${view/name};

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -28,10 +28,9 @@ class TestRelationChoice(FunctionalTestCase):
         self.assertEquals(folder, content.realtionchoice.to_object)
 
         browser.login().visit(content, view='@@edit')
-        selected = json.loads(browser.css(
-            '.selected_items').first.attrib['data-select'])
+        selected = browser.css('.selected_items [type="hidden"]')
         self.assertEquals('/'.join(folder.getPhysicalPath()),
-                          selected[0]['path'])
+                          selected[0].attrib['value'])
 
     @browsing
     def test_relation_choice_with_removed_relation(self, browser):

--- a/ftw/referencewidget/tests/widgets.py
+++ b/ftw/referencewidget/tests/widgets.py
@@ -13,6 +13,11 @@ class ReferenceBrowserWidget(PloneWidget):
         return bool(node.css('div.referencewidget'))
 
     def fill(self, values):
+
+        # Clear widget data
+        for item in self.css('.selected_items input[type="hidden"]'):
+            item.node.getparent().remove(item.node)
+
         field = self.css('input[type="hidden"]').first
 
         if isinstance(values, basestring):

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -99,7 +99,7 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
 
         return obj
 
-    def js_value(self):
+    def get_items(self):
         result = []
 
         if not self.value:
@@ -123,7 +123,7 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
             if obj:
                 result.append(obj_to_dict(obj))
 
-        return json.dumps(result)
+        return result
 
     def get_start_path(self):
         if self.start:


### PR DESCRIPTION
This way the widget behaves more like all other plone widgets.

I need to make this hack, because the template of the input element is a handlebars js template. 