### PR TITLE
Implement path restriction option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,16 +42,18 @@ Example:
 
 .. code:: python
 
-    def custom_filter(source, value):
-        return bool(..)
+    from ftw.referencewidget.filter import DefaultSelectable
 
+    class CustomClass(DefaultSelectable):
+        def is_selectable(self):
+            return bool(..)
     ...
 
     directives.widget(realtionchoice_restricted_title=ReferenceWidgetFactory)
     realtionchoice_restricted_title = RelationChoice(
         title=_(u'Related Choice Restricted Title'),
         source=ReferenceObjSourceBinder(
-            selectable_function=custom_filter),
+            selectable_class=CustomClass),
         default=None,
         required=False,
     )
@@ -64,7 +66,7 @@ Only `ReferenceObjSourceBinder` are supported. The SourceBinder takes the follow
 - nonselectable: These Types are not selectable
 - allow_nonsearched_types: If this is set to true all the types will be traversable and selectable.
 - override: drops all global config and the base query if a list is passed to the widget. All types need to be added to be selectable.
-- selectable_function: Custom function to determine if a content is selectable or not.
+- selectable_class: Custom ISelectable Class to determine if a content is selectable or not.
 
 The parameters are same as for the widget (Backwards compatibility with 1.x releases).
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Implement path restriction option.
+  [mathias.leimgruber]
+
 - Render hidden input elements for given references, instead of
   render them only by Javascript. This way the widget behaves more
   like all other plone widgets.

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -1,3 +1,4 @@
+from ftw.referencewidget.selectable import DefaultSelectable
 from ftw.referencewidget.sources import ReferenceObjSourceBinder
 from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.app.dexterity import MessageFactory as _
@@ -47,8 +48,10 @@ class IRelationChoiceExample(Interface):
 alsoProvides(IRelationChoiceExample, IFormFieldProvider)
 
 
-def custom_filter(source, value):
-    return value.Title() == 'Immutable title'
+class CustomSelectableClass(DefaultSelectable):
+
+    def is_selectable(self):
+        return self.content.Title() == 'Immutable title'
 
 
 class IRelationChoiceRestricted(Interface):
@@ -69,7 +72,7 @@ class IRelationChoiceRestricted(Interface):
     realtionchoice_restricted_title = RelationChoice(
         title=_(u'Related Choice Restricted Title'),
         source=ReferenceObjSourceBinder(
-            selectable_function=custom_filter),
+            selectable_class=CustomSelectableClass),
         default=None,
         required=False,
     )

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -77,4 +77,14 @@ class IRelationChoiceRestricted(Interface):
         required=False,
     )
 
+    directives.widget(realtionchoice_restricted_path=ReferenceWidgetFactory)
+    realtionchoice_restricted_path = RelationChoice(
+        title=_(u'Related Choice Restricted Title'),
+        source=ReferenceObjSourceBinder(
+            root_path='/testfolder'),
+        default=None,
+        required=False,
+    )
+
+
 alsoProvides(IRelationChoiceRestricted, IFormFieldProvider)

--- a/ftw/referencewidget/browser/generate_pathbar.py
+++ b/ftw/referencewidget/browser/generate_pathbar.py
@@ -1,10 +1,8 @@
 from Acquisition import aq_parent
+from ftw.referencewidget.browser.utils import get_root_path_from_source
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.Five import BrowserView
-from z3c.relationfield.schema import RelationChoice
-from z3c.relationfield.schema import RelationList
-from zope.schema import List
 import json
 
 
@@ -24,7 +22,7 @@ class GeneratePathbar(BrowserView):
         obj = widget.context.unrestrictedTraverse(originpoint)
         results = []
 
-        root_path = self._get_path_from_source(widget.field)
+        root_path = get_root_path_from_source(widget)
 
         while True:
             clickable = mtool.checkPermission('View', obj)
@@ -41,18 +39,3 @@ class GeneratePathbar(BrowserView):
                 obj = aq_parent(obj)
         self.request.RESPONSE.setHeader("Content-type", "application/json")
         return json.dumps(results)
-
-    def _get_path_from_source(self, field):
-        if isinstance(field, RelationList) or isinstance(field, List):
-            value_type = getattr(field, 'value_type', None)
-
-            if isinstance(value_type, RelationChoice):
-                source = value_type.source(self.context)
-                return source.root_path
-
-        elif isinstance(field, RelationChoice):
-            source = field.source(self.context)
-            return source.root_path
-
-        else:
-            return None

--- a/ftw/referencewidget/browser/search.py
+++ b/ftw/referencewidget/browser/search.py
@@ -1,4 +1,5 @@
 from ftw.referencewidget.browser.utils import extend_with_batching
+from ftw.referencewidget.browser.utils import get_root_path_from_source
 from ftw.referencewidget.browser.utils import get_selectable_types
 from ftw.referencewidget.browser.utils import get_sort_options
 from ftw.referencewidget.browser.utils import get_sort_order_options
@@ -32,6 +33,10 @@ class SearchView(BrowserView):
                                              u'modified').encode('utf-8')}
 
         query.update(self.context.traversal_query)
+
+        root_path = get_root_path_from_source(self.context)
+        if root_path:
+            query['path'] = root_path
 
         catalog = getToolByName(self.context.context, 'portal_catalog')
         results = catalog(query)

--- a/ftw/referencewidget/browser/utils.py
+++ b/ftw/referencewidget/browser/utils.py
@@ -154,3 +154,20 @@ def get_sort_order_options(request):
         )
 
     return options
+
+
+def get_root_path_from_source(widget):
+    field = widget.field
+    if isinstance(field, RelationList) or isinstance(field, List):
+        value_type = getattr(field, 'value_type', None)
+
+        if isinstance(value_type, RelationChoice):
+            source = value_type.source(widget.context)
+            return source.root_path
+
+    elif isinstance(field, RelationChoice):
+        source = field.source(widget.context)
+        return source.root_path
+
+    else:
+        return None

--- a/ftw/referencewidget/selectable.py
+++ b/ftw/referencewidget/selectable.py
@@ -1,0 +1,40 @@
+from ftw.referencewidget.browser.utils import get_selectable_types_by_source
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class ISelectable(Interface):
+    """Defines the ISelectable behavior"""
+
+    def __init__(source, content):
+        """Needs a ISource (from zope schema) and a DX content object"""
+
+    def is_selectable():
+        """"
+        Return ``True`` when the object is selectable, ``False``
+        when it is not selectable.
+        """
+
+
+class DefaultSelectable(object):
+    implements(ISelectable)
+
+    def __init__(self, source, content):
+        self.source = source
+        self.content = content
+
+    def __call__(self):
+        return self.is_selectable()
+
+    def is_selectable(self):
+        portal_type = self.content.portal_type
+        selectable_types = get_selectable_types_by_source(self.source)
+
+        valid_type = portal_type in selectable_types
+
+        valid_path = True
+        if self.source.root_path:
+            path = '/'.join(self.content.getPhysicalPath())
+            valid_path = path.startswith(self.source.root_path)
+
+        return valid_type and valid_path

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -1,34 +1,20 @@
-from ftw.referencewidget.browser.utils import get_selectable_types_by_source
+from ftw.referencewidget.selectable import DefaultSelectable
+from ftw.referencewidget.selectable import ISelectable
 from plone import api
 from zope.interface import implements
+from zope.interface.verify import verifyClass
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import ISource
-
-
-def default_filter(source, value):
-    """"
-    Return ``True`` when the object is selectable, ``False``
-    when it is not selectable.
-
-    """
-    valid_type = value.portal_type in get_selectable_types_by_source(source)
-
-    valid_path = True
-    if source.root_path:
-        path = '/'.join(value.getPhysicalPath())
-        valid_path = path.startswith(source.root_path)
-
-    return valid_type and valid_path
 
 
 class ReferenceObjPathSource(object):
 
     implements(ISource)
 
-    def __init__(self, context, selectable_function, selectable, nonselectable,
+    def __init__(self, context, selectable_class, selectable, nonselectable,
                  override, allow_nonsearched_types, root_path):
         self.context = context
-        self.selectable_function = selectable_function
+        self.selectable_class = selectable_class
         self.selectable = selectable
         self.nonselectable = nonselectable
         self.override = override
@@ -36,20 +22,23 @@ class ReferenceObjPathSource(object):
         self.root_path = root_path
 
     def __contains__(self, value):
-        return self.selectable_function(source=self, value=value)
+        if verifyClass(ISelectable, self.selectable_class):
+            return self.selectable_class(source=self, content=value)()
+        else:
+            raise TypeError('Not a ISelectable class provided')
 
 
 class ReferenceObjSourceBinder(object):
     implements(IContextSourceBinder)
 
     def __init__(self,
-                 selectable_function=None,
+                 selectable_class=None,
                  selectable=None,
                  nonselectable=None,
                  override=None,
                  allow_nonsearched_types=None,
                  root_path=None):
-        self.selectable_function = selectable_function or default_filter
+        self.selectable_class = selectable_class or DefaultSelectable
         self.selectable = selectable or []
         self.nonselectable = nonselectable or []
         self.override = override or False
@@ -59,7 +48,7 @@ class ReferenceObjSourceBinder(object):
     def __call__(self, context):
         self.context = context
         return ReferenceObjPathSource(context,
-                                      self.selectable_function,
+                                      self.selectable_class,
                                       self.selectable,
                                       self.nonselectable,
                                       self.override,

--- a/ftw/referencewidget/sources.py
+++ b/ftw/referencewidget/sources.py
@@ -1,7 +1,8 @@
+from ftw.referencewidget.browser.utils import get_selectable_types_by_source
+from plone import api
+from zope.interface import implements
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import ISource
-from zope.interface import implements
-from ftw.referencewidget.browser.utils import get_selectable_types_by_source
 
 
 def default_filter(source, value):
@@ -10,8 +11,14 @@ def default_filter(source, value):
     when it is not selectable.
 
     """
+    valid_type = value.portal_type in get_selectable_types_by_source(source)
 
-    return value.portal_type in get_selectable_types_by_source(source)
+    valid_path = True
+    if source.root_path:
+        path = '/'.join(value.getPhysicalPath())
+        valid_path = path.startswith(source.root_path)
+
+    return valid_type and valid_path
 
 
 class ReferenceObjPathSource(object):
@@ -19,13 +26,14 @@ class ReferenceObjPathSource(object):
     implements(ISource)
 
     def __init__(self, context, selectable_function, selectable, nonselectable,
-                 override, allow_nonsearched_types):
+                 override, allow_nonsearched_types, root_path):
         self.context = context
         self.selectable_function = selectable_function
         self.selectable = selectable
         self.nonselectable = nonselectable
         self.override = override
         self.allow_nonsearched_types = allow_nonsearched_types
+        self.root_path = root_path
 
     def __contains__(self, value):
         return self.selectable_function(source=self, value=value)
@@ -39,17 +47,30 @@ class ReferenceObjSourceBinder(object):
                  selectable=None,
                  nonselectable=None,
                  override=None,
-                 allow_nonsearched_types=None):
+                 allow_nonsearched_types=None,
+                 root_path=None):
         self.selectable_function = selectable_function or default_filter
         self.selectable = selectable or []
         self.nonselectable = nonselectable or []
         self.override = override or False
         self.allow_nonsearched_types = allow_nonsearched_types or False
+        self.root_path = root_path
 
     def __call__(self, context):
+        self.context = context
         return ReferenceObjPathSource(context,
                                       self.selectable_function,
                                       self.selectable,
                                       self.nonselectable,
                                       self.override,
-                                      self.allow_nonsearched_types)
+                                      self.allow_nonsearched_types,
+                                      self._get_root_path())
+
+    def _get_root_path(self):
+        if callable(self.root_path):
+            return self.root_path(self.context)
+        elif isinstance(self.root_path, basestring):
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            return portal_path + self.root_path
+        else:
+            return None

--- a/ftw/referencewidget/tests/test_generate_pathbar.py
+++ b/ftw/referencewidget/tests/test_generate_pathbar.py
@@ -2,13 +2,16 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.referencewidget.browser.generate_pathbar import GeneratePathbar
 from ftw.referencewidget.testing import FTW_REFERENCE_FUNCTIONAL_TESTING
+from ftw.referencewidget.tests import FunctionalTestCase
 from ftw.referencewidget.tests.views.form import TestView
+from ftw.testbrowser import browsing
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from unittest2 import TestCase
 import json
+import transaction
 
 
 class TestGeneratePathbar(TestCase):
@@ -46,3 +49,37 @@ class TestGeneratePathbar(TestCase):
         self.assertEquals(3, len(result))
         self.assertEquals("/plone/folder/test", result[2]['path'])
         self.assertEquals("Test", result[2]['title'])
+
+
+class TestPathBarWithPathRestriction(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPathBarWithPathRestriction, self).setUp()
+        self.setup_fti(additional_behaviors=[
+            'ftw.referencewidget.behaviors.IRelationChoiceRestricted'])
+        self.grant('Manager')
+
+    def test_root_path_restriction_of_source_is_respected(self):
+        testfolder = create(Builder('folder')
+                            .titled(u'Test folder')
+                            .with_id('testfolder'))
+        subfolder = create(Builder('folder')
+                           .within(testfolder)
+                           .titled(u'Some folder'))
+        content = create(Builder('sample content')
+                         .within(subfolder)
+                         .titled(u'Some folder'))
+
+        pathbar = self._get_pathbar_from_widget(
+            content,
+            'IRelationChoiceRestricted.realtionchoice_restricted_path')
+
+        self.assertEquals(3, len(pathbar))
+        self.assertEquals('/'.join(testfolder.getPhysicalPath()),
+                          pathbar[0]['path'])
+
+    def _get_pathbar_from_widget(self, source, name):
+        form = source.unrestrictedTraverse('@@edit').form_instance
+        form.update()
+        widget = form.widgets[name]
+        return json.loads(GeneratePathbar(widget, widget.request)())

--- a/ftw/referencewidget/tests/test_relation_choice.py
+++ b/ftw/referencewidget/tests/test_relation_choice.py
@@ -87,7 +87,7 @@ class TestRelationChoiceRestricted(FunctionalTestCase):
                           content1.realtionchoice_restricted.to_object)
 
     @browsing
-    def test_custom_selectable_function_for_source_binder(self, browser):
+    def test_custom_selectable_class_for_source_binder(self, browser):
 
         folder = create(Builder('folder').titled(u'Some folder'))
 

--- a/ftw/referencewidget/tests/test_source.py
+++ b/ftw/referencewidget/tests/test_source.py
@@ -27,6 +27,32 @@ class TestReferenceObjSource(FunctionalTestCase):
         self.assertNotIn(folder, source)
         self.assertNotIn(sibling, source)
 
+    def test_root_path_callable(self):
+        folder = create(Builder('folder'))
+        subfolder = create(Builder('folder').within(folder))
+        subsubfolder = create(Builder('folder').within(subfolder))
+        sibling = create(Builder('folder'))
+
+        def current_path(context):
+            return '/'.join(context.getPhysicalPath())
+
+        source = ReferenceObjSourceBinder(
+            root_path=current_path)(subfolder)
+
+        self.assertIn(subsubfolder, source)
+        self.assertIn(subfolder, source)
+
+        self.assertNotIn(folder, source)
+        self.assertNotIn(sibling, source)
+
+        sibling_source = source = ReferenceObjSourceBinder(
+            root_path=current_path)(sibling)
+
+        self.assertNotIn(folder, sibling_source)
+        self.assertNotIn(subfolder, sibling_source)
+        self.assertNotIn(subsubfolder, sibling_source)
+        self.assertIn(sibling, sibling_source)
+
     def test_nonselectable_option(self):
         folder = create(Builder('folder'))
         content = create(Builder('sample content'))

--- a/ftw/referencewidget/tests/test_source.py
+++ b/ftw/referencewidget/tests/test_source.py
@@ -25,3 +25,62 @@ class TestReferenceObjSource(FunctionalTestCase):
 
         self.assertNotIn(folder, source)
         self.assertNotIn(sibling, source)
+
+    def test_nonselectable_option(self):
+        folder = create(Builder('folder'))
+        content = create(Builder('sample content'))
+
+        source_content = create(Builder('folder'))
+
+        source = ReferenceObjSourceBinder(
+            nonselectable=['Folder'])(source_content)
+
+        self.assertNotIn(folder, source)
+        self.assertIn(content, source)
+
+    def test_custom_selectable_function(self):
+        folder = create(Builder('folder'))
+        folder_titled = create(Builder('folder').titled(u'dummy title'))
+        source_content = create(Builder('sample content'))
+
+        def custom_selectable_functon(source, value):
+            return u'dummy title' == value.title
+
+        source = ReferenceObjSourceBinder(
+            selectable_function=custom_selectable_functon)(source_content)
+
+        self.assertNotIn(folder, source)
+        self.assertIn(folder_titled, source)
+
+    def test_force_selectable_types(self):
+        folder = create(Builder('folder'))
+        sample = create(Builder('sample content'))
+        source_content = create(Builder('sample content'))
+
+        source = ReferenceObjSourceBinder(
+            override=True,
+            selectable=['Folder'])(source_content)
+
+        self.assertNotIn(sample, source)
+        self.assertIn(folder, source)
+
+    def test_not_searched_types_are_disabled_by_default(self):
+        folder = create(Builder('folder'))
+        sample = create(Builder('sample content'))
+
+        self._set_not_searched_types('Folder')
+        source = ReferenceObjSourceBinder()(sample)
+        self.assertNotIn(folder, source)
+
+    def test_allow_not_searched_types(self):
+        folder = create(Builder('folder'))
+        sample = create(Builder('sample content'))
+
+        self._set_not_searched_types('Folder')
+        source = ReferenceObjSourceBinder(
+            allow_nonsearched_types=True)(sample)
+        self.assertIn(folder, source)
+
+    def _set_not_searched_types(self, *types):
+        site_properties = self.portal.portal_properties.site_properties
+        site_properties.types_not_searched = tuple(types)

--- a/ftw/referencewidget/tests/test_source.py
+++ b/ftw/referencewidget/tests/test_source.py
@@ -1,0 +1,27 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.referencewidget.sources import ReferenceObjSourceBinder
+from ftw.referencewidget.tests import FunctionalTestCase
+
+
+class TestReferenceObjSource(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestReferenceObjSource, self).setUp()
+        self.setup_fti()
+        self.grant('Manager')
+
+    def test_root_path_restriction(self):
+        folder = create(Builder('folder'))
+        subfolder = create(Builder('folder').within(folder))
+        subsubfolder = create(Builder('folder').within(subfolder))
+        sibling = create(Builder('folder'))
+
+        source = ReferenceObjSourceBinder(
+            root_path='/folder/folder')(subfolder)
+
+        self.assertIn(subsubfolder, source)
+        self.assertIn(subfolder, source)
+
+        self.assertNotIn(folder, source)
+        self.assertNotIn(sibling, source)

--- a/ftw/referencewidget/tests/test_source.py
+++ b/ftw/referencewidget/tests/test_source.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.referencewidget.selectable import DefaultSelectable
 from ftw.referencewidget.sources import ReferenceObjSourceBinder
 from ftw.referencewidget.tests import FunctionalTestCase
 
@@ -38,16 +39,17 @@ class TestReferenceObjSource(FunctionalTestCase):
         self.assertNotIn(folder, source)
         self.assertIn(content, source)
 
-    def test_custom_selectable_function(self):
+    def test_custom_selectable_class(self):
         folder = create(Builder('folder'))
         folder_titled = create(Builder('folder').titled(u'dummy title'))
         source_content = create(Builder('sample content'))
 
-        def custom_selectable_functon(source, value):
-            return u'dummy title' == value.title
+        class CustomSelectable(DefaultSelectable):
+            def is_selectable(self):
+                return u'dummy title' == self.content.title
 
         source = ReferenceObjSourceBinder(
-            selectable_function=custom_selectable_functon)(source_content)
+            selectable_class=CustomSelectable)(source_content)
 
         self.assertNotIn(folder, source)
         self.assertIn(folder_titled, source)


### PR DESCRIPTION
I also moved from a selectable_function to a selectable_class since the logic to get the selectable content is going to be more complex now. 

This allows us for example to extend de default selector class. With a function we need copy the default logic every time. 