### PR TITLE
Show localized news date in title for all news items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.4.3 (unreleased)
+1.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show localized news date in title for all news items [Nachtalb]
 
 
 1.4.2 (2017-08-29)

--- a/ftw/referencewidget/browser/search.py
+++ b/ftw/referencewidget/browser/search.py
@@ -4,6 +4,7 @@ from ftw.referencewidget.browser.utils import get_selectable_types
 from ftw.referencewidget.browser.utils import get_sort_options
 from ftw.referencewidget.browser.utils import get_sort_order_options
 from ftw.referencewidget.browser.utils import get_traversal_types
+from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 import json
@@ -45,7 +46,7 @@ class SearchView(BrowserView):
         json_prep['batching'] = batch_html
 
         traversel_type = get_traversal_types(self.context)
-
+        plone = api.portal.get()
         for item in results:
             contenttype = 'contenttype-' \
                 + item.portal_type.replace('.', '-').lower()
@@ -53,7 +54,9 @@ class SearchView(BrowserView):
             traversable = item.is_folderish and  \
                 (item.portal_type in traversel_type)
 
-            label = '{0} ({1})'.format(item.Title, item.getPath())
+            date = ' (%s)' % plone.toLocalizedTime(item.start) if item.start else ''
+
+            label = '{0}{1} ({2})'.format(item.Title, date, item.getPath())
             json_prep['items'].append({'title': label,
                                        'path': item.getPath(),
                                        'selectable': True,

--- a/ftw/referencewidget/tests/builders.py
+++ b/ftw/referencewidget/tests/builders.py
@@ -1,4 +1,5 @@
 from ftw.builder import registry
+from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.dexterity import DexterityBuilder
 
 
@@ -7,3 +8,9 @@ class SampleContentBuilder(DexterityBuilder):
 
 registry.builder_registry.register(
     'refwidget sample content', SampleContentBuilder)
+
+
+class EventsBuilder(ArchetypesBuilder):
+    portal_type = 'Event'
+
+registry.builder_registry.register('event', EventsBuilder)

--- a/ftw/referencewidget/tests/test_search_view.py
+++ b/ftw/referencewidget/tests/test_search_view.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.referencewidget.browser.search import SearchView
 from ftw.referencewidget.testing import FTW_REFERENCE_FUNCTIONAL_TESTING
 from ftw.referencewidget.tests import FunctionalTestCase
 from ftw.referencewidget.tests.views.form import TestView
+from ftw.testing.freezer import freeze
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -41,6 +44,20 @@ class TestGeneratePathbar(TestCase):
 
         self.assertEquals("/plone/testfolder/test", items[0]['path'])
         self.assertEquals("Test (/plone/testfolder/test)", items[0]['title'])
+
+    def test_search_view_on_news(self):
+        with freeze(datetime(2017, 10, 04)):
+            create(Builder('event').within(self.folder).titled(u"Event"))
+        self.widget.request['term'] = 'Event'
+        self.widget.request['sort_on'] = 'sortable_title'
+        view = SearchView(self.widget, self.widget.request)
+        result = view()
+        results = json.loads(result)
+        items = results['items']
+        self.assertEquals(1, len(items))
+        self.assertEquals(u'/plone/testfolder/event', items[0]['path'])
+        self.assertEquals(u'Event (Oct 04, 2017) (/plone/testfolder/event)',
+                          items[0]['title'])
 
     def test_only_correct_types(self):
         self.widget.override = True

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_require = [
     'ftw.builder',
     'unittest2',
     'ftw.testbrowser >= 1.26.1',
+    'ftw.testing',
 ]
 
 setup(name='ftw.referencewidget',


### PR DESCRIPTION
Issue for this PR: https://github.com/4teamwork/bern.web/issues/1325

The date is shown for all Content Types which have set the start index. This includes eg. `Event` from plone or `ftw.news.News`

Eg. this would look like: "Some News Title (Oct 04, 2017)" or when you search for an item "Some News Title (Oct 04, 2017) (/path/to/item)"