### PR TITLE
Add option to search in current path

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- Add option to search in current path. [Nachtalb]
 - Show localized news date in title for all news items [Nachtalb]
 
 

--- a/ftw/referencewidget/browser/search.py
+++ b/ftw/referencewidget/browser/search.py
@@ -19,6 +19,8 @@ class SearchView(BrowserView):
                      'sortOrderOptions': get_sort_order_options(self.request)}
 
         search_term = self.request.get('term')
+        request_path = self.request.get('request_path')
+        only_current_path = self.request.get('search_current_path') == 'on'
         if not search_term:
             return json.dumps(json_prep)
 
@@ -32,6 +34,8 @@ class SearchView(BrowserView):
                                                 u'ascending').encode('utf-8'),
                  'sort_on': self.request.get('sort_on',
                                              u'modified').encode('utf-8')}
+        if only_current_path and request_path:
+            query['path'] = request_path
 
         query.update(self.context.traversal_query)
 
@@ -48,6 +52,9 @@ class SearchView(BrowserView):
         traversel_type = get_traversal_types(self.context)
         plone = api.portal.get()
         for item in results:
+            if only_current_path and request_path and item.getPath() == query['path']:
+                continue
+
             contenttype = 'contenttype-' \
                 + item.portal_type.replace('.', '-').lower()
 

--- a/ftw/referencewidget/locales/de/LC_MESSAGES/ftw.referencewidget.po
+++ b/ftw/referencewidget/locales/de/LC_MESSAGES/ftw.referencewidget.po
@@ -59,3 +59,8 @@ msgstr "Nicht sortiert"
 msgid "sortable_title"
 msgstr "Titel"
 
+#. Default: "Search only in current path"
+#: ./ftw/referencewidget/widget.py:82
+msgid "checkbox_search_current_path"
+msgstr "Suche nur im aktuellen Pfad"
+

--- a/ftw/referencewidget/locales/ftw.referencewidget.pot
+++ b/ftw/referencewidget/locales/ftw.referencewidget.pot
@@ -59,3 +59,7 @@ msgstr ""
 msgid "sortable_title"
 msgstr ""
 
+#. Default: "Search only in current path"
+#: ./ftw/referencewidget/widget.py:82
+msgid "checkbox_search_current_path"
+msgstr ""

--- a/ftw/referencewidget/resources/refwidget.css
+++ b/ftw/referencewidget/resources/refwidget.css
@@ -56,6 +56,9 @@ div.refbrowser .search{
 div.refbrowser .search input{
     min-width: 180px;
 }
+div.refbrowser .search .searchCurrentPathLabel{
+    display: block;
+}
 
 div.refbrowser .search button{
     float:right;

--- a/ftw/referencewidget/resources/refwidget.js
+++ b/ftw/referencewidget/resources/refwidget.js
@@ -41,6 +41,7 @@
       widget.sel_type = "";
       widget.page = 1;
       widget.term = "";
+      widget.search_current_path = 0;
 
       widget.list_template = Handlebars.compile($("#listing-template").html());
       widget.checkbox_template = Handlebars.compile($("#checkbox-template").html());
@@ -135,20 +136,24 @@
       event.stopPropagation();
       event.preventDefault();
 
-      var value = $(".refbrowser .searchField").val();
+      var term = $(".refbrowser .searchField").val();
+      var search_current_path = $(".refbrowser #searchCurrentPath").val();
 
-      if (value.length === 0) {
+      if (term.length === 0) {
         return;
       }
 
 
-      widget.term = value;
+      widget.term = term;
+      widget.search_current_path = search_current_path;
       widget.page = 1;
       widget.search_results(widget);
     };
 
     initRefBrowser.prototype.search_results = function(widget){
       var payload = {"term": widget.term,
+                     "search_current_path": widget.search_current_path,
+                     "request_path": widget.request_path,
                      "page": widget.page,
                      "sort_on": $('.refbrowser select[name="sort_on"]').val(),
                      "sort_order": $('.refbrowser select[name="sort_order"]').val()

--- a/ftw/referencewidget/templates/handlebars.html
+++ b/ftw/referencewidget/templates/handlebars.html
@@ -5,6 +5,10 @@
                 <div class="search">
                     <input class="searchField" name="refbrowser-search" type="text" />
                     <button class="searchButton" name="refbrowser-search" type="submit">{{search}}</button>
+                    <label for="searchCurrentPath" class="searchCurrentPathLabel">
+                        {{search_current_path}}
+                        <input type="checkbox" name="refbrowser-search-current-path" id="searchCurrentPath">
+                    </label>
                 </div>
             <div class="sorter"></div>
             </div>

--- a/ftw/referencewidget/tests/test_search_view.py
+++ b/ftw/referencewidget/tests/test_search_view.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.referencewidget.browser.search import SearchView
@@ -43,6 +42,21 @@ class TestGeneratePathbar(TestCase):
         self.assertEquals("Testfolder (/plone/testfolder)", items[1]['title'])
 
         self.assertEquals("/plone/testfolder/test", items[0]['path'])
+        self.assertEquals("Test (/plone/testfolder/test)", items[0]['title'])
+
+    def test_search_only_from_current_path(self):
+        create(Builder('file').titled('Test File - not in search results'))
+
+        self.widget.request['term'] = 'tes'
+        self.widget.request['sort_on'] = 'sortable_title'
+        self.widget.request['search_current_path'] = 'on'
+        self.widget.request['request_path'] = '/'.join(self.folder.getPhysicalPath())
+
+        view = SearchView(self.widget, self.widget.request)
+        result = view()
+        results = json.loads(result)
+        items = results['items']
+        self.assertEquals(1, len(items))
         self.assertEquals("Test (/plone/testfolder/test)", items[0]['title'])
 
     def test_search_view_on_news(self):

--- a/ftw/referencewidget/widget.py
+++ b/ftw/referencewidget/widget.py
@@ -79,9 +79,13 @@ class ReferenceBrowserWidget(widget.HTMLTextInputWidget, Widget):
 
     def translations(self):
         msg_search = _(u"button_seach", default="Search")
+        msg_search_current_path = _(u"checkbox_search_current_path",
+                                 default="Search only in current path")
         msg_close = _(u"button_close", default="Close")
         msg_sort_by = _(u"label_sort_by", default="Sort by")
         return json.dumps({'search': translate(msg_search,
+                                               context=self.request),
+                           'search_current_path': translate(msg_search_current_path,
                                                context=self.request),
                            'close': translate(msg_close,
                                               context=self.request),


### PR DESCRIPTION
Issue for this PR: 4teamwork/bern.web#1325

Adds a checkbox to only search items which are below the current site level.
 
In this example you can see that if you are on the page 'Foo', you wont find the same called subpages which are in the Site `Bar`:
```
Search term:  "Some"
Current path: "/root/foo"
 
✕ /root
✕   /foo
✔       /Some Site
✕       /Other Site
✕   /bar
✕       /Some Site
✕       /Other Site

```