### PR TITLE
Fix wrong news date behind news in the jsongenerator.py

### DIFF
--- a/ftw/referencewidget/browser/jsongenerator.py
+++ b/ftw/referencewidget/browser/jsongenerator.py
@@ -42,9 +42,8 @@ class ReferenceJsonEndpoint(BrowserView):
             contenttype = item.portal_type.replace('.', '-').lower()
 
             label = item.Title or item.id
-            if item.portal_type == 'ftw.news.News':
-                news_object = item.getObject()
-                label += ' (%s)' % plone.toLocalizedTime(news_object.news_date)
+            label += ' (%s)' % plone.toLocalizedTime(item.start) if item.start else ''
+
             obj_dict = {'path': item.getPath(),
                         'id': item.id,
                         'title': label,


### PR DESCRIPTION
Use  `item.start` instead of `item.news_date` like in https://github.com/4teamwork/ftw.referencewidget/blob/e49b149ac9246f3087fddb969f2b02f168bec08b/ftw/referencewidget/browser/search.py#L64