### PR TITLE
Fix UniCodeDecodeError while displaying the news date and fix search in current path

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix searching for current path only. [mathias.leimgruber]
+- Fix UniCodeDecodeError while displaying the news date. [mathias.leimgruber]
 
 
 1.5.0 (2017-10-23)

--- a/ftw/referencewidget/browser/jsongenerator.py
+++ b/ftw/referencewidget/browser/jsongenerator.py
@@ -42,7 +42,7 @@ class ReferenceJsonEndpoint(BrowserView):
             contenttype = item.portal_type.replace('.', '-').lower()
 
             label = item.Title or item.id
-            label += ' (%s)' % plone.toLocalizedTime(item.start) if item.start else ''
+            label += ' (%s)' % plone.toLocalizedTime(item.start).encode('utf-8') if item.start else ''
 
             obj_dict = {'path': item.getPath(),
                         'id': item.id,

--- a/ftw/referencewidget/browser/search.py
+++ b/ftw/referencewidget/browser/search.py
@@ -20,7 +20,7 @@ class SearchView(BrowserView):
 
         search_term = self.request.get('term')
         request_path = self.request.get('request_path')
-        only_current_path = self.request.get('search_current_path') == 'on'
+        only_current_path = self.request.get('search_current_path') == '1'
         if not search_term:
             return json.dumps(json_prep)
 

--- a/ftw/referencewidget/resources/refwidget.js
+++ b/ftw/referencewidget/resources/refwidget.js
@@ -137,7 +137,7 @@
       event.preventDefault();
 
       var term = $(".refbrowser .searchField").val();
-      var search_current_path = $(".refbrowser #searchCurrentPath").val();
+      var search_current_path = $(".refbrowser #searchCurrentPath:checked").length;
 
       if (term.length === 0) {
         return;

--- a/ftw/referencewidget/tests/test_search_view.py
+++ b/ftw/referencewidget/tests/test_search_view.py
@@ -49,7 +49,7 @@ class TestGeneratePathbar(TestCase):
 
         self.widget.request['term'] = 'tes'
         self.widget.request['sort_on'] = 'sortable_title'
-        self.widget.request['search_current_path'] = 'on'
+        self.widget.request['search_current_path'] = '1'
         self.widget.request['request_path'] = '/'.join(self.folder.getPhysicalPath())
 
         view = SearchView(self.widget, self.widget.request)


### PR DESCRIPTION
The first issue appeared if there was a umlaut in the title, since the localize datetime method returned a unicode.

The second problem was a browser problem, since $('some checkbox').val() always returns `on`. 