### PR TITLE
Fix error on loading a page with a DataGrid when its default is not set

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - No longer use "plone.directives.form". [mbaechtold]
+- Fix an issue when loading a page with GridDataField turns out in a error [Nachtalb]
 
 
 1.5.2 (2017-10-23)

--- a/ftw/referencewidget/converter.py
+++ b/ftw/referencewidget/converter.py
@@ -133,6 +133,8 @@ class GridDataConverter(converter.BaseDataConverter):
     adapts(IList, IDataGridField)
 
     def toWidgetValue(self, value):
+        if not value:
+            return value
         new_value = []
         for row in value:
             new_row = {}
@@ -145,6 +147,8 @@ class GridDataConverter(converter.BaseDataConverter):
         return new_value
 
     def toFieldValue(self, value):
+        if not value:
+            return value
         intids = component.queryUtility(IIntIds)
         for row in value:
             for key in row:


### PR DESCRIPTION
The referencewidget's converter for DataGrids expected a iterable value, even though the value could have been a None when the default for the Field was not set.