### PR TITLE
No longer use "plone.directives.form".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer use "plone.directives.form". [mbaechtold]
 
 
 1.5.2 (2017-10-23)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -6,7 +6,6 @@ from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.app.dexterity import MessageFactory as _
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.directives import form
 from plone.supermodel import model
 from plone.supermodel.model import fieldset
 from z3c.relationfield.schema import RelationChoice, RelationList
@@ -71,7 +70,7 @@ class IDataGridFieldExample(Interface):
     """Demo behavior containing a DataGridField.
 
     """
-    form.widget('the_data_grid', DataGridFieldFactory, allow_reorder=True)
+    directives.widget('the_data_grid', DataGridFieldFactory, allow_reorder=True)
     the_data_grid = schema.List(
         title=u'The Data Grid',
         value_type=DictRow(title=u'the_data_grid_row', schema=IDataGridRow),


### PR DESCRIPTION
"plone.directives.form" is no longer installed automatically through one of our dependencies, probably because it was removed from "collective.z3cform.datagridfield" (see https://github.com/collective/collective.z3cform.datagridfield/blob/bff7b3be73fe22725cbf9c83ce45ebf710fc4693/CHANGES.rst#130-2017-11-22).

Fixes https://ci.4teamwork.ch/builds/126486/tasks/196675