### PR TITLE
Require "five.pt" < 3.0.

### DIFF
--- a/test-plone-4.3.x-chameleon.cfg
+++ b/test-plone-4.3.x-chameleon.cfg
@@ -3,4 +3,4 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.referencewidget
-test-egg += five.pt
+test-egg += five.pt < 3.0


### PR DESCRIPTION
"five.pt" has been marked as deprecated as the code has been integrated into "Zope2" >= 4. So they removed all the code from "five.pt" and released "five.pt" 3.0 which requires "Zope2" >= 4.0a2.

We cannot yet update to "Zope2" >= 4 so we need to use an older release of "five.pt".