### PR TITLE
Disable amd check for handlbar.js.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Disable amd check for handlbar.js [mathias.leimgruber]
+
 - Add Plone 5.1 support. [mathias.leimgruber]
 
 

--- a/ftw/referencewidget/resources/handlebars.js
+++ b/ftw/referencewidget/resources/handlebars.js
@@ -27,8 +27,6 @@ THE SOFTWARE.
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
 	else if(typeof exports === 'object')
 		exports["Handlebars"] = factory();
 	else


### PR DESCRIPTION
Plone 5 dev mode will not work otherwise.