### PR TITLE
Ensure handlebars.js dependency is available for the product's JS

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Restrict handlebars.js to authenticated users. [tinagerber]
 
 
 2.2.0 (2019-12-16)

--- a/ftw/referencewidget/profiles/default/jsregistry.xml
+++ b/ftw/referencewidget/profiles/default/jsregistry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
 
-  <javascript enabled="True" id="++resource++ftw.referencewidget/handlebars.js" compression="none" insert-after="++resource++plone.app.jquery.js" />
+  <javascript enabled="True" id="++resource++ftw.referencewidget/handlebars.js" compression="none" insert-after="++resource++plone.app.jquery.js" authenticated="True" />
 
   <javascript enabled="True" id="++resource++ftw.referencewidget/refwidget.js" insert-after="++resource++ftw.referencewidget/handlebars.js"
   authenticated="True" />

--- a/ftw/referencewidget/upgrades/20200115110839_restrict_handle_bars_to_authenticated_users/jsregistry.xml
+++ b/ftw/referencewidget/upgrades/20200115110839_restrict_handle_bars_to_authenticated_users/jsregistry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript enabled="True" id="++resource++ftw.referencewidget/handlebars.js" compression="none" insert-before="++resource++ftw.referencewidget/refwidget.js" authenticated="True" />
+
+</object>

--- a/ftw/referencewidget/upgrades/20200115110839_restrict_handle_bars_to_authenticated_users/upgrade.py
+++ b/ftw/referencewidget/upgrades/20200115110839_restrict_handle_bars_to_authenticated_users/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+import pkg_resources
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
+
+
+class RestrictHandleBarsToAuthenticatedUsers(UpgradeStep):
+    """Restrict handle bars to authenticated users.
+    """
+
+    def __call__(self):
+        if not IS_PLONE_5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
In production mode, handlebar.js and refwidget.js weren't in the same 'Merged JS Compilation' file. This caused errors if the files were not loaded equally fast.