### PR TITLE
Fix DictRow, DataGridFieldFactory imports to be compatible with 1.x and 2.x of collective.z3cform.datagridfield.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix DictRow, DataGridFieldFactory imports to be compatible with 1.x and 2.x of collective.z3cform.datagridfield. [mathias.leimgruber]
 
 
 3.0.2 (2021-01-07)

--- a/ftw/referencewidget/behaviors.py
+++ b/ftw/referencewidget/behaviors.py
@@ -1,5 +1,5 @@
-from collective.z3cform.datagridfield import DataGridFieldFactory
-from collective.z3cform.datagridfield import DictRow
+from collective.z3cform.datagridfield.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield.row import DictRow
 from ftw.referencewidget.selectable import DefaultSelectable
 from ftw.referencewidget.sources import ReferenceObjSourceBinder
 from ftw.referencewidget.widget import ReferenceWidgetFactory


### PR DESCRIPTION
Version 2 got a bigger refactoring, to avoid circular imports in collective.z3cform.datagridfield they removed those imports from one of the __init__.py's 

See https://github.com/collective/collective.z3cform.datagridfield/commit/3d4064a47a9062394acab8f2b65e61025875a150#diff-b7466768d5acffdf1a9b06abfb886a06ff495ef020cc04fea1b3d42b622c1c48